### PR TITLE
修复pull request后actions出现Error: fatal: not in a git directory错误

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup docker-compose
-        uses: KengoTODA/actions-setup-docker-compose@v1.0.3
+        uses: KengoTODA/actions-setup-docker-compose@v1
         with:
           version: "v2.2.1"
 
@@ -73,7 +73,7 @@ jobs:
           path: rust-release.test
 
       - name: Clone action repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: actions
       - uses: actions/cache@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup docker-compose
         uses: KengoTODA/actions-setup-docker-compose@v1.0.3
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create/Update tag
-        uses: rickstaa/action-create-tag@v1.2.0
+        uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ env.TEST_TAG }}
           message: "ci test"


### PR DESCRIPTION
https://github.com/rickstaa/action-create-tag/issues/10 提到了因为git的一个cve漏洞，导致了Error: fatal: not in a git directory。

解决方法:

- 升级到v2到actions/checkout@v3
- 使用rickstaa/action-create-tag@v1到v1.3.0以上。（我改为了默认v1最新版）

最后升级了一些第三方的actions版本